### PR TITLE
feat: support genai metrics and add metrics in eino instrumentation

### DIFF
--- a/pkg/inst-api-semconv/instrumenter/ai/ai_metrics.go
+++ b/pkg/inst-api-semconv/instrumenter/ai/ai_metrics.go
@@ -1,0 +1,199 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ai
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/alibaba/loongsuite-go-agent/pkg/inst-api-semconv/instrumenter/utils"
+	"github.com/alibaba/loongsuite-go-agent/pkg/inst-api/instrumenter"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+)
+
+// GenAI metrics instrumentation (Stability: development).
+// Spec: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/
+const (
+	gen_ai_client_token_usage        = "gen_ai.client.token.usage"
+	gen_ai_client_operation_duration = "gen_ai.client.operation.duration"
+)
+
+type AIClientMetric struct {
+	key                     attribute.Key
+	clientOperationDuration metric.Float64Histogram
+	clientTokenUsage        metric.Int64Histogram
+}
+
+var _ instrumenter.OperationListener = (*AIClientMetric)(nil)
+
+var mu sync.Mutex
+
+var aiMetricsConv = map[attribute.Key]bool{
+	semconv.GenAIOperationNameKey: true,
+	semconv.GenAISystemKey:        true,
+	semconv.ErrorTypeKey:          true,
+	semconv.GenAIRequestModelKey:  true,
+	semconv.ServerAddressKey:      true,
+	semconv.ServerPortKey:         true,
+	semconv.GenAIResponseModelKey: true,
+}
+
+var globalMeter metric.Meter
+
+func InitAIMetrics(m metric.Meter) {
+	mu.Lock()
+	defer mu.Unlock()
+	globalMeter = m
+}
+
+func AIClientMetrics(key string) *AIClientMetric {
+	mu.Lock()
+	defer mu.Unlock()
+	return &AIClientMetric{key: attribute.Key(key)}
+}
+
+// for test only
+func newAIClientMatric(key string, meter metric.Meter) (*AIClientMetric, error) {
+	m := &AIClientMetric{
+		key: attribute.Key(key),
+	}
+	clientOperationDuration, err := newAIClientOperationDurationMeasures(meter)
+	if err != nil {
+		return nil, err
+	}
+	clientTokenUsage, err := newAIClientTokenUsageMeasures(meter)
+	m.clientOperationDuration = clientOperationDuration
+	m.clientTokenUsage = clientTokenUsage
+	return m, nil
+}
+
+func newAIClientOperationDurationMeasures(meter metric.Meter) (metric.Float64Histogram, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if meter == nil {
+		return nil, errors.New("nil meter")
+	}
+	d, err := meter.Float64Histogram(gen_ai_client_operation_duration,
+		metric.WithUnit("s"),
+		metric.WithDescription("Duration of chat completion operation."),
+		metric.WithExplicitBucketBoundaries(0.01, 0.02, 0.04, 0.08, 0.16, 0.32, 0.64, 1.28, 2.56, 5.12, 10.24, 20.48, 40.96, 81.92),
+	)
+	if err == nil {
+		return d, nil
+	} else {
+		return d, errors.New(fmt.Sprintf("failed to create gen_ai.client.operation.duration histogram, %v", err))
+	}
+}
+
+func newAIClientTokenUsageMeasures(meter metric.Meter) (metric.Int64Histogram, error) {
+	mu.Lock()
+	defer mu.Unlock()
+	if meter == nil {
+		return nil, errors.New("nil meter")
+	}
+	d, err := meter.Int64Histogram(gen_ai_client_token_usage,
+		metric.WithUnit("token"),
+		metric.WithDescription("Number of tokens used in prompt and completions."),
+		metric.WithExplicitBucketBoundaries(1, 4, 16, 64, 256, 1024, 4096, 16384, 65536, 262144, 1048576, 4194304, 16777216, 67108864),
+	)
+	if err == nil {
+		return d, nil
+	} else {
+		return d, errors.New(fmt.Sprintf("failed to create gen_ai.client.token.usage histogram, %v", err))
+	}
+}
+
+type aiMatricContext struct {
+	startTime       time.Time
+	startAttributes []attribute.KeyValue
+}
+
+func (a AIClientMetric) OnBeforeStart(parentContext context.Context, startTimestamp time.Time) context.Context {
+	return parentContext
+}
+
+func (a AIClientMetric) OnBeforeEnd(ctx context.Context, startAttributes []attribute.KeyValue, startTimestamp time.Time) context.Context {
+	return context.WithValue(ctx, a.key, aiMatricContext{
+		startTime:       startTimestamp,
+		startAttributes: startAttributes,
+	})
+}
+
+func (a AIClientMetric) OnAfterStart(ctx context.Context, endTimestamp time.Time) {
+	return
+}
+
+func (a AIClientMetric) OnAfterEnd(ctx context.Context, endAttributes []attribute.KeyValue, endTime time.Time) {
+	mc := ctx.Value(a.key).(aiMatricContext)
+	startTime, startAttributes := mc.startTime, mc.startAttributes
+	// end attributes should be shadowed by AttrsShadower
+	if a.clientOperationDuration == nil {
+		var err error
+		// second change to init the metric
+		a.clientOperationDuration, err = newAIClientOperationDurationMeasures(globalMeter)
+		if err != nil {
+			log.Printf("failed to create clientOperationDuration, err is %v\n", err)
+		}
+	}
+	if a.clientTokenUsage == nil {
+		var err error
+		// second change to init the metric
+		a.clientTokenUsage, err = newAIClientTokenUsageMeasures(globalMeter)
+		if err != nil {
+			log.Printf("failed to create clientTokenUsage, err is %v\n", err)
+		}
+	}
+	endAttributes = append(endAttributes, startAttributes...)
+	n, metricsAttrs := utils.Shadow(endAttributes, aiMetricsConv)
+
+	// record the client operation duration
+	if a.clientOperationDuration != nil {
+		a.clientOperationDuration.Record(ctx, endTime.Sub(startTime).Seconds(), metric.WithAttributeSet(attribute.NewSet(metricsAttrs[0:n]...)))
+	}
+
+	var inputTokens, outputTokens attribute.Value
+	var hasInputTokens, hasOutputTokens bool
+	for _, kv := range endAttributes {
+		switch kv.Key {
+		case semconv.GenAIUsageInputTokensKey:
+			inputTokens = kv.Value
+			hasInputTokens = true
+		case semconv.GenAIUsageOutputTokensKey:
+			outputTokens = kv.Value
+			hasOutputTokens = true
+		}
+		if hasInputTokens && hasOutputTokens {
+			break
+		}
+	}
+
+	// record the client token usage
+	if hasInputTokens {
+		a.clientTokenUsage.Record(ctx, inputTokens.AsInt64(),
+			metric.WithAttributeSet(attribute.NewSet(metricsAttrs[0:n]...)),
+			metric.WithAttributes(semconv.GenAITokenTypeInput))
+	}
+	if hasOutputTokens {
+		a.clientTokenUsage.Record(ctx, outputTokens.AsInt64(),
+			metric.WithAttributeSet(attribute.NewSet(metricsAttrs[0:n]...)),
+			metric.WithAttributes(semconv.GenAITokenTypeCompletion))
+	}
+}

--- a/pkg/inst-api-semconv/instrumenter/ai/ai_metrics_test.go
+++ b/pkg/inst-api-semconv/instrumenter/ai/ai_metrics_test.go
@@ -1,16 +1,17 @@
-// Copyright (c) 2024 Alibaba Group Holding Ltd.
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//      http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package ai
 
 import (
@@ -44,6 +45,7 @@ func TestAIClientMetric(t *testing.T) {
 	ctx = client.OnBeforeStart(ctx, start)
 	ctx = client.OnBeforeEnd(ctx, []attribute.KeyValue{}, start)
 	client.OnAfterStart(ctx, time.Now())
+	ctx = context.WithValue(ctx, TimeToFirstTokenKey{}, time.Now())
 	client.OnAfterEnd(ctx, []attribute.KeyValue{
 		semconv.GenAISystemKey.String("openai"),
 		semconv.GenAIOperationNameKey.String("chat"),
@@ -62,7 +64,7 @@ func TestAIClientMetric(t *testing.T) {
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		names[m.Name] = true
 	}
-	if !names["gen_ai.client.operation.duration"] || !names["gen_ai.client.token.usage"] {
+	if !names["gen_ai.client.operation.duration"] || !names["gen_ai.client.token.usage"] || !names["gen_ai.server.time_to_first_token"] {
 		panic("required metrics not found")
 	}
 }
@@ -86,6 +88,7 @@ func TestLazyAIClientMetric(t *testing.T) {
 		semconv.GenAIUsageOutputTokens(222),
 	}, start)
 	client.OnAfterStart(ctx, time.Now())
+	ctx = context.WithValue(ctx, TimeToFirstTokenKey{}, time.Now())
 	client.OnAfterEnd(ctx, []attribute.KeyValue{
 		semconv.GenAISystemKey.String("openai"),
 		semconv.GenAIOperationNameKey.String("chat"),
@@ -102,7 +105,7 @@ func TestLazyAIClientMetric(t *testing.T) {
 	for _, m := range rm.ScopeMetrics[0].Metrics {
 		names[m.Name] = true
 	}
-	if !names["gen_ai.client.operation.duration"] || !names["gen_ai.client.token.usage"] {
+	if !names["gen_ai.client.operation.duration"] || !names["gen_ai.client.token.usage"] || !names["gen_ai.server.time_to_first_token"] {
 		panic("required metrics not found")
 	}
 }

--- a/pkg/inst-api-semconv/instrumenter/ai/ai_metrics_test.go
+++ b/pkg/inst-api-semconv/instrumenter/ai/ai_metrics_test.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2024 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package ai
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alibaba/loongsuite-go-agent/pkg/inst-api-semconv/instrumenter/utils"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"go.opentelemetry.io/otel/sdk/resource"
+	semconv "go.opentelemetry.io/otel/semconv/v1.30.0"
+)
+
+func TestAIClientMetric(t *testing.T) {
+	reader := metric.NewManualReader()
+	res := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName("genai-service"),
+		semconv.ServiceVersion("v1.0.0"),
+	)
+	mp := metric.NewMeterProvider(metric.WithReader(reader), metric.WithResource(res))
+	m := mp.Meter("test-meter")
+	client, err := newAIClientMatric("test", m)
+	if err != nil {
+		panic(err)
+	}
+	ctx := context.Background()
+	start := time.Now()
+	ctx = client.OnBeforeStart(ctx, start)
+	ctx = client.OnBeforeEnd(ctx, []attribute.KeyValue{}, start)
+	client.OnAfterStart(ctx, time.Now())
+	client.OnAfterEnd(ctx, []attribute.KeyValue{
+		semconv.GenAISystemKey.String("openai"),
+		semconv.GenAIOperationNameKey.String("chat"),
+		semconv.GenAIUsageInputTokens(123),
+		semconv.GenAIUsageOutputTokens(456),
+	}, time.Now())
+
+	rm := &metricdata.ResourceMetrics{}
+	reader.Collect(ctx, rm)
+
+	if len(rm.ScopeMetrics) <= 0 || len(rm.ScopeMetrics[0].Metrics) <= 0 {
+		panic("no metrics collected")
+	}
+
+	names := map[string]bool{}
+	for _, m := range rm.ScopeMetrics[0].Metrics {
+		names[m.Name] = true
+	}
+	if !names["gen_ai.client.operation.duration"] || !names["gen_ai.client.token.usage"] {
+		panic("required metrics not found")
+	}
+}
+
+func TestLazyAIClientMetric(t *testing.T) {
+	reader := metric.NewManualReader()
+	res := resource.NewWithAttributes(
+		semconv.SchemaURL,
+		semconv.ServiceName("genai-service"),
+		semconv.ServiceVersion("v1.0.0"),
+	)
+	mp := metric.NewMeterProvider(metric.WithReader(reader), metric.WithResource(res))
+	m := mp.Meter("test-meter")
+	InitAIMetrics(m)
+	client := AIClientMetrics("genai.metric")
+	ctx := context.Background()
+	start := time.Now()
+	ctx = client.OnBeforeStart(ctx, start)
+	ctx = client.OnBeforeEnd(ctx, []attribute.KeyValue{
+		semconv.GenAIUsageInputTokens(111),
+		semconv.GenAIUsageOutputTokens(222),
+	}, start)
+	client.OnAfterStart(ctx, time.Now())
+	client.OnAfterEnd(ctx, []attribute.KeyValue{
+		semconv.GenAISystemKey.String("openai"),
+		semconv.GenAIOperationNameKey.String("chat"),
+	}, time.Now())
+
+	rm := &metricdata.ResourceMetrics{}
+	reader.Collect(ctx, rm)
+
+	if len(rm.ScopeMetrics) <= 0 || len(rm.ScopeMetrics[0].Metrics) <= 0 {
+		panic("no metrics collected")
+	}
+
+	names := map[string]bool{}
+	for _, m := range rm.ScopeMetrics[0].Metrics {
+		names[m.Name] = true
+	}
+	if !names["gen_ai.client.operation.duration"] || !names["gen_ai.client.token.usage"] {
+		panic("required metrics not found")
+	}
+}
+
+func TestAINilMeter(t *testing.T) {
+	_, err := newAIClientMatric("test", nil)
+	if err == nil {
+		panic("expected error on nil meter")
+	}
+}
+
+func TestAIAttrShadower(t *testing.T) {
+	attrs := []attribute.KeyValue{
+		semconv.GenAISystemKey.String("openai"),
+		semconv.GenAIOperationNameKey.String("chat"),
+		semconv.GenAIRequestModel("gpt-4"),
+		attribute.String("other", "value"),
+	}
+	n, shadowed := utils.Shadow(attrs, aiMetricsConv)
+	if n != 3 {
+		panic("expected 3 valid metric attributes")
+	}
+	if shadowed[n].Key != "other" {
+		panic("unexpected attribute shadowing order")
+	}
+}

--- a/pkg/otel_setup.go
+++ b/pkg/otel_setup.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 
 	"github.com/alibaba/loongsuite-go-agent/pkg/core/meter"
+	"github.com/alibaba/loongsuite-go-agent/pkg/inst-api-semconv/instrumenter/ai"
 	"github.com/alibaba/loongsuite-go-agent/pkg/inst-api-semconv/instrumenter/db"
 	"github.com/alibaba/loongsuite-go-agent/pkg/inst-api-semconv/instrumenter/experimental"
 	"github.com/alibaba/loongsuite-go-agent/pkg/inst-api-semconv/instrumenter/http"
@@ -196,6 +197,8 @@ func initMetrics() error {
 	rpc.InitRpcMetrics(m)
 	// init db metrics
 	db.InitDbMetrics(m)
+	// init ai metrics
+	ai.InitAIMetrics(m)
 	// nacos experimental metrics
 	experimental.InitNacosExperimentalMetrics(m)
 	// DefaultMinimumReadMemStatsInterval is 15 second

--- a/pkg/rules/eino/eino_common_otel_instrumenter.go
+++ b/pkg/rules/eino/eino_common_otel_instrumenter.go
@@ -83,5 +83,6 @@ func BuildEinoCommonInstrumenter() instrumenter.Instrumenter[einoRequest, einoRe
 			Name:    utils.EINO_SCOPE_NAME,
 			Version: version.Tag,
 		}).
+		AddOperationListeners(ai.AIClientMetrics("eino-common")).
 		BuildInstrumenter()
 }

--- a/pkg/rules/eino/eino_handler.go
+++ b/pkg/rules/eino/eino_handler.go
@@ -87,7 +87,8 @@ func einoModelCallHandler(config ChatModelConfig) *callbacksutils.ModelCallbackH
 			request := ctx.Value(llmRequestKey{}).(einoLLMRequest)
 			response := einoLLMResponse{}
 			if output.TokenUsage != nil {
-				response.usageOutputTokens = int64(output.TokenUsage.TotalTokens)
+				response.usageOutputTokens = int64(output.TokenUsage.CompletionTokens)
+				request.usageInputTokens = int64(output.TokenUsage.PromptTokens)
 			}
 			if output.Message != nil && output.Message.ResponseMeta != nil {
 				response.responseFinishReasons = []string{output.Message.ResponseMeta.FinishReason}
@@ -141,7 +142,8 @@ func einoModelCallHandler(config ChatModelConfig) *callbacksutils.ModelCallbackH
 					}
 				}
 				if usage != nil {
-					response.usageOutputTokens = int64(usage.TotalTokens)
+					response.usageOutputTokens = int64(usage.CompletionTokens)
+					request.usageInputTokens = int64(usage.PromptTokens)
 				}
 				response.responseModel = request.modelName
 				einoLLMInstrument.End(ctx, request, response, nil)

--- a/pkg/rules/eino/eino_handler.go
+++ b/pkg/rules/eino/eino_handler.go
@@ -19,6 +19,9 @@ import (
 	"io"
 	"log"
 	"runtime/debug"
+	"time"
+
+	"github.com/alibaba/loongsuite-go-agent/pkg/inst-api-semconv/instrumenter/ai"
 
 	"github.com/bytedance/sonic"
 	"github.com/cloudwego/eino/callbacks"
@@ -111,6 +114,7 @@ func einoModelCallHandler(config ChatModelConfig) *callbacksutils.ModelCallbackH
 				}()
 				response := einoLLMResponse{}
 				var outs []*model.CallbackOutput
+				firstTokenTime := time.Now()
 				for {
 					chunk, err := output.Recv()
 					if err == io.EOF {
@@ -146,6 +150,7 @@ func einoModelCallHandler(config ChatModelConfig) *callbacksutils.ModelCallbackH
 					request.usageInputTokens = int64(usage.PromptTokens)
 				}
 				response.responseModel = request.modelName
+				ctx = context.WithValue(ctx, ai.TimeToFirstTokenKey{}, firstTokenTime)
 				einoLLMInstrument.End(ctx, request, response, nil)
 			}()
 			return ctx

--- a/pkg/rules/eino/eino_llm_otel_instrucmenter.go
+++ b/pkg/rules/eino/eino_llm_otel_instrucmenter.go
@@ -108,5 +108,6 @@ func BuildEinoLLMInstrumenter() instrumenter.Instrumenter[einoLLMRequest, einoLL
 			Name:    utils.EINO_SCOPE_NAME,
 			Version: version.Tag,
 		}).
+		AddOperationListeners(ai.AIClientMetrics("eino-llm")).
 		BuildInstrumenter()
 }

--- a/test/eino/v0.3.51/test_chatmodel_metrics.go
+++ b/test/eino/v0.3.51/test_chatmodel_metrics.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/alibaba/loongsuite-go-agent/test/verifier"
+	"github.com/cloudwego/eino/schema"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+)
+
+func main() {
+	ctx := context.Background()
+	cm, _ := NewMockOpenAIChatModelForInvoke(ctx)
+	_, err := cm.Generate(ctx, []*schema.Message{schema.UserMessage("Hello")})
+	if err != nil {
+		panic(err)
+	}
+	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"gen_ai.client.operation.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No gen_ai.client.operation.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if point.DataPoints[0].Count <= 0 {
+				panic("gen_ai.client.operation.duration metrics count is not positive, actually " + strconv.Itoa(int(point.DataPoints[0].Count)))
+			}
+			verifier.VerifyGenAIOperationDurationMetricsAttributes(point.DataPoints[0].Attributes.ToSlice(), "chat", "eino", "mock-chat", "mock-chat")
+		},
+		"gen_ai.client.token.usage": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No gen_ai.client.token.usage metrics received!")
+			}
+			fmt.Println(mrs.ScopeMetrics[0].Metrics[0])
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[int64])
+			if point.DataPoints[0].Count <= 0 || point.DataPoints[1].Count <= 0 {
+				panic("gen_ai.client.token.usage metrics count is not positive")
+			}
+			verifier.VerifyGenAITokenUsageMetricsAttributes(point.DataPoints[0].Attributes.ToSlice(), "chat", "eino", "mock-chat", "mock-chat", "input")
+			verifier.VerifyGenAITokenUsageMetricsAttributes(point.DataPoints[1].Attributes.ToSlice(), "chat", "eino", "mock-chat", "mock-chat", "output")
+		},
+	})
+}

--- a/test/eino/v0.3.51/test_invoke_chatmodel_metrics.go
+++ b/test/eino/v0.3.51/test_invoke_chatmodel_metrics.go
@@ -16,7 +16,6 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"strconv"
 
 	"github.com/alibaba/loongsuite-go-agent/test/verifier"
@@ -46,7 +45,6 @@ func main() {
 			if len(mrs.ScopeMetrics) <= 0 {
 				panic("No gen_ai.client.token.usage metrics received!")
 			}
-			fmt.Println(mrs.ScopeMetrics[0].Metrics[0])
 			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[int64])
 			if point.DataPoints[0].Count <= 0 || point.DataPoints[1].Count <= 0 {
 				panic("gen_ai.client.token.usage metrics count is not positive")

--- a/test/eino/v0.3.51/test_stream_chatmodel_metrics.go
+++ b/test/eino/v0.3.51/test_stream_chatmodel_metrics.go
@@ -1,0 +1,65 @@
+// Copyright (c) 2025 Alibaba Group Holding Ltd.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"github.com/alibaba/loongsuite-go-agent/test/verifier"
+	"github.com/cloudwego/eino/schema"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	"strconv"
+)
+
+func main() {
+	ctx := context.Background()
+	cm, _ := NewMockOpenAIChatModelForStream(ctx)
+	_, err := cm.Stream(ctx, []*schema.Message{schema.UserMessage("Hello")})
+	if err != nil {
+		panic(err)
+	}
+	verifier.WaitAndAssertMetrics(map[string]func(metricdata.ResourceMetrics){
+		"gen_ai.client.operation.duration": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No gen_ai.client.operation.duration metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if point.DataPoints[0].Count <= 0 {
+				panic("gen_ai.client.operation.duration metrics count is not positive, actually " + strconv.Itoa(int(point.DataPoints[0].Count)))
+			}
+			verifier.VerifyGenAIOperationDurationMetricsAttributes(point.DataPoints[0].Attributes.ToSlice(), "chat", "eino", "mock-chat", "mock-chat")
+		},
+		"gen_ai.client.token.usage": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No gen_ai.client.token.usage metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[int64])
+			if point.DataPoints[0].Count <= 0 || point.DataPoints[1].Count <= 0 {
+				panic("gen_ai.client.token.usage metrics count is not positive")
+			}
+			verifier.VerifyGenAITokenUsageMetricsAttributes(point.DataPoints[0].Attributes.ToSlice(), "chat", "eino", "mock-chat", "mock-chat", "input")
+			verifier.VerifyGenAITokenUsageMetricsAttributes(point.DataPoints[1].Attributes.ToSlice(), "chat", "eino", "mock-chat", "mock-chat", "output")
+		},
+		"gen_ai.server.time_to_first_token": func(mrs metricdata.ResourceMetrics) {
+			if len(mrs.ScopeMetrics) <= 0 {
+				panic("No gen_ai.server.time_to_first_token metrics received!")
+			}
+			point := mrs.ScopeMetrics[0].Metrics[0].Data.(metricdata.Histogram[float64])
+			if point.DataPoints[0].Count <= 0 {
+				panic("gen_ai.server.time_to_first_token metrics count is not positive")
+			}
+			verifier.VerifyGenAIOperationDurationMetricsAttributes(point.DataPoints[0].Attributes.ToSlice(), "chat", "eino", "mock-chat", "mock-chat")
+		},
+	})
+}

--- a/test/eino_tests.go
+++ b/test/eino_tests.go
@@ -33,7 +33,8 @@ func init() {
 		NewGeneralTestCase("eino-qwen-invoke-test", eino_module_name, "v0.3.51", "", "1.18", "", TestQwenInvokeEino),
 		NewGeneralTestCase("eino-qwen-stream-test", eino_module_name, "v0.3.51", "", "1.18", "", TestQwenStreamEino),
 		NewGeneralTestCase("eino-document-test", eino_module_name, "v0.3.51", "", "1.18", "", TestDocumentEino),
-		NewGeneralTestCase("test-chatmodel-metrics", eino_module_name, "v0.3.51", "", "1.18", "", TestChatModelMetrics),
+		NewGeneralTestCase("test-invoke-chatmodel-metrics", eino_module_name, "v0.3.51", "", "1.18", "", TestInvokeChatModelMetrics),
+		NewGeneralTestCase("test-stream-chatmodel-metrics", eino_module_name, "v0.3.51", "", "1.18", "", TestStreamChatModelMetrics),
 		NewLatestDepthTestCase("eino-latest-depth-test", eino_dependency_name, eino_module_name, "v0.3.51", "", "1.18", "", TestOpenAIInvokeEino),
 		NewMuzzleTestCase("eino-muzzle-test-react-agent", eino_dependency_name, eino_module_name, "v0.3.51", "", "1.18", "", []string{"go", "build", "test_react_agent.go", "eino_common.go"}),
 		NewMuzzleTestCase("eino-muzzle-test-openai-invoke", eino_dependency_name, eino_module_name, "v0.3.51", "", "1.18", "", []string{"go", "build", "test_openai_invoke_chatmodel.go", "eino_common.go"}),
@@ -116,8 +117,14 @@ func TestQwenStreamEino(t *testing.T, env ...string) {
 	RunApp(t, "test_qwen_stream_chatmodel", env...)
 }
 
-func TestChatModelMetrics(t *testing.T, env ...string) {
+func TestInvokeChatModelMetrics(t *testing.T, env ...string) {
 	UseApp("eino/v0.3.51")
-	RunGoBuild(t, "go", "build", "test_chatmodel_metrics.go", "eino_common.go")
-	RunApp(t, "test_chatmodel_metrics", env...)
+	RunGoBuild(t, "go", "build", "test_invoke_chatmodel_metrics.go", "eino_common.go")
+	RunApp(t, "test_invoke_chatmodel_metrics", env...)
+}
+
+func TestStreamChatModelMetrics(t *testing.T, env ...string) {
+	UseApp("eino/v0.3.51")
+	RunGoBuild(t, "go", "build", "test_stream_chatmodel_metrics.go", "eino_common.go")
+	RunApp(t, "test_stream_chatmodel_metrics", env...)
 }

--- a/test/eino_tests.go
+++ b/test/eino_tests.go
@@ -33,6 +33,7 @@ func init() {
 		NewGeneralTestCase("eino-qwen-invoke-test", eino_module_name, "v0.3.51", "", "1.18", "", TestQwenInvokeEino),
 		NewGeneralTestCase("eino-qwen-stream-test", eino_module_name, "v0.3.51", "", "1.18", "", TestQwenStreamEino),
 		NewGeneralTestCase("eino-document-test", eino_module_name, "v0.3.51", "", "1.18", "", TestDocumentEino),
+		NewGeneralTestCase("test-chatmodel-metrics", eino_module_name, "v0.3.51", "", "1.18", "", TestChatModelMetrics),
 		NewLatestDepthTestCase("eino-latest-depth-test", eino_dependency_name, eino_module_name, "v0.3.51", "", "1.18", "", TestOpenAIInvokeEino),
 		NewMuzzleTestCase("eino-muzzle-test-react-agent", eino_dependency_name, eino_module_name, "v0.3.51", "", "1.18", "", []string{"go", "build", "test_react_agent.go", "eino_common.go"}),
 		NewMuzzleTestCase("eino-muzzle-test-openai-invoke", eino_dependency_name, eino_module_name, "v0.3.51", "", "1.18", "", []string{"go", "build", "test_openai_invoke_chatmodel.go", "eino_common.go"}),
@@ -113,4 +114,10 @@ func TestQwenStreamEino(t *testing.T, env ...string) {
 	UseApp("eino/v0.3.51")
 	RunGoBuild(t, "go", "build", "test_qwen_stream_chatmodel.go", "eino_common.go")
 	RunApp(t, "test_qwen_stream_chatmodel", env...)
+}
+
+func TestChatModelMetrics(t *testing.T, env ...string) {
+	UseApp("eino/v0.3.51")
+	RunGoBuild(t, "go", "build", "test_chatmodel_metrics.go", "eino_common.go")
+	RunApp(t, "test_chatmodel_metrics", env...)
 }

--- a/test/verifier/verifier.go
+++ b/test/verifier/verifier.go
@@ -120,6 +120,21 @@ func VerifyDbMetricsAttributes(attrs []attribute.KeyValue, dbSystem, operationNa
 	Assert(GetAttribute(attrs, string(semconv.ServerAddressKey)).AsString() == serverAddress, "Expected server.address to be %s, got %s", serverAddress, GetAttribute(attrs, string(semconv.ServerAddressKey)).AsString())
 }
 
+func VerifyGenAIOperationDurationMetricsAttributes(attrs []attribute.KeyValue, operationName, system, requestModel, responseModel string) {
+	Assert(GetAttribute(attrs, string(semconv.GenAIOperationNameKey)).AsString() == operationName, "Expected gen_ai.operation.name to be %s, got %s", operationName, GetAttribute(attrs, string(semconv.GenAIOperationNameKey)).AsString())
+	Assert(GetAttribute(attrs, string(semconv.GenAISystemKey)).AsString() == system, "Expected gen_ai.system to be %s, got %s", system, GetAttribute(attrs, string(semconv.GenAISystemKey)).AsString())
+	Assert(GetAttribute(attrs, string(semconv.GenAIRequestModelKey)).AsString() == requestModel, "Expected gen_ai.request.model to be %s, got %s", requestModel, GetAttribute(attrs, string(semconv.GenAIRequestModelKey)).AsString())
+	Assert(GetAttribute(attrs, string(semconv.GenAIResponseModelKey)).AsString() == responseModel, "Expected gen_ai.response.model to be %s, got %s", responseModel, GetAttribute(attrs, string(semconv.GenAIResponseModelKey)).AsString())
+}
+
+func VerifyGenAITokenUsageMetricsAttributes(attrs []attribute.KeyValue, operationName, system, requestModel, responseModel, tokenType string) {
+	Assert(GetAttribute(attrs, string(semconv.GenAIOperationNameKey)).AsString() == operationName, "Expected gen_ai.operation.name to be %s, got %s", operationName, GetAttribute(attrs, string(semconv.GenAIOperationNameKey)).AsString())
+	Assert(GetAttribute(attrs, string(semconv.GenAISystemKey)).AsString() == system, "Expected gen_ai.system to be %s, got %s", system, GetAttribute(attrs, string(semconv.GenAISystemKey)).AsString())
+	Assert(GetAttribute(attrs, string(semconv.GenAIRequestModelKey)).AsString() == requestModel, "Expected gen_ai.request.model to be %s, got %s", requestModel, GetAttribute(attrs, string(semconv.GenAIRequestModelKey)).AsString())
+	Assert(GetAttribute(attrs, string(semconv.GenAIResponseModelKey)).AsString() == responseModel, "Expected gen_ai.response.model to be %s, got %s", responseModel, GetAttribute(attrs, string(semconv.GenAIResponseModelKey)).AsString())
+	Assert(GetAttribute(attrs, string(semconv.GenAITokenTypeKey)).AsString() == tokenType, "Expected gen_ai.token.type to be %s, got %s", tokenType, GetAttribute(attrs, string(semconv.GenAITokenTypeKey)).AsString())
+}
+
 func VerifyRpcClientMetricsAttributes(attrs []attribute.KeyValue, method, service, system, serverAddr string) {
 	Assert(GetAttribute(attrs, "rpc.method").AsString() == method, "Except rpc.method to be %s, got %s", method, GetAttribute(attrs, "rpc.method").AsString())
 	Assert(GetAttribute(attrs, "rpc.service").AsString() == service, "Except rpc.service to be %s, got %s", service, GetAttribute(attrs, "rpc.service").AsString())


### PR DESCRIPTION
#### Description:

1. Support for OpenTelemetry GenAI metrics instrumentation 
    - gen_ai.client.token.usage
    - gen_ai.client.operation.duration
    - gen_ai.server.time_to_first_token
2. Integrate these metrics into Eino instrumentation

> Note: The OpenTelemetry GenAI semantic conventions are currently in Stability: **development** and may change in future versions. See: https://opentelemetry.io/docs/specs/semconv/gen-ai/gen-ai-metrics/