### PR TITLE
Adding golangci-lint to improve code quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ otel
 otel-*
 *.log
 .otel-build
+bin
 
 test/errors-test/errors-test
 test/errorstest/errorstest

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,38 @@
+# Copyright (c) 2024 Alibaba Group Holding Ltd.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http:#www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+run:
+  timeout: 10m
+  tests: true
+
+linters:
+  enable:
+    - govet
+    - goimports
+    - misspell
+    - errcheck
+    - staticcheck
+    - typecheck
+    - unused
+
+linters-settings:
+  goimports:
+    local-prefixes: github.com/alibaba/loongsuite-go-agent
+  misspell:
+    locale: US
+
+issues:
+  exclude-use-default: false
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,7 @@
 
 #-------------------------------------------------------------------------------
 # General build options
-mk_path  := $(abspath $(lastword $(MAKEFILE_LIST))) # Get the absolute path of the current Makefile
-mk_dir   := $(dir $(mk_path)) # Extract the directory path from the Makefile path
-tool_bin := $(mk_dir)bin # Define the path to the 'bin' directory located in the same directory as the Makefile
+tool_bin := $(abspath ./bin)
 
 MAIN_VERSION := $(shell git describe --tags --abbrev=0 | sed 's/^v//')
 
@@ -150,9 +148,9 @@ package-pkg:
 LINTER := $(tool_bin)/golangci-lint
 lint:
 	@if [ ! -x "$(LINTER)" ]; then \
-		echo "golangci-lint not found, installing..."; \
+  		echo "golangci-lint not found, installing to $(tool_bin)..."; \
 		mkdir -p $(tool_bin); \
 		GOBIN=$(tool_bin) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8; \
     fi
 	@echo "Running golangci-lint..."
-	$(LINTER) run ./... --timeout=10m
+	$(LINTER) run -v --config .golangci.yml ./...

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,10 @@
 
 #-------------------------------------------------------------------------------
 # General build options
+mk_path  := $(abspath $(lastword $(MAKEFILE_LIST))) # Get the absolute path of the current Makefile
+mk_dir   := $(dir $(mk_path)) # Extract the directory path from the Makefile path
+tool_bin := $(mk_dir)bin # Define the path to the 'bin' directory located in the same directory as the Makefile
+
 MAIN_VERSION := $(shell git describe --tags --abbrev=0 | sed 's/^v//')
 
 CURRENT_OS := $(shell uname -s | tr '[:upper:]' '[:lower:]')
@@ -139,3 +143,16 @@ package-pkg:
 	@tar -czf $(PKG_GZIP) --exclude='*.log' --exclude='*.string' --exclude='*.pprof' --exclude='*.gz' $(PKG_TMP)
 	@mv alibaba-pkg.gz tool/data/
 	@rm -rf $(PKG_TMP)
+
+#-------------------------------------------------------------------------------
+# Code Quality: Linting with golangci-lint
+.PHONY: lint
+LINTER := $(tool_bin)/golangci-lint
+lint:
+	@if [ ! -x "$(LINTER)" ]; then \
+		echo "golangci-lint not found, installing..."; \
+		mkdir -p $(tool_bin); \
+		GOBIN=$(tool_bin) go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.64.8; \
+    fi
+	@echo "Running golangci-lint..."
+	$(LINTER) run ./... --timeout=10m


### PR DESCRIPTION
fix #520.

1. We should add the `bin` directory to isolate the user environment from the project environment.
2. This bin directory can be used as an extension of subsequent plugins, such as proto, buf, lincense-eye, ginkgo, etc
3. Modify `Makefile` and add `.golangci.yml`

