### PR TITLE
fix grpc unused dependency

### DIFF
--- a/pkg/rules/grpc/go.mod
+++ b/pkg/rules/grpc/go.mod
@@ -22,6 +22,5 @@ require (
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.23.0 // indirect
-	google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 // indirect
 	google.golang.org/protobuf v1.36.5 // indirect
 )


### PR DESCRIPTION
fix go build error :

```
# otel go build -o ./bin/authing ./authing/main.go
Error:
[0] command [go build -a -x -n -o ./bin/authing ./authing/main.go authing/otel.runtime.go]
[1] dryRunFail: go: downloading google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013
# get https://goproxy.cn/google.golang.org/genproto/@v/v0.0.0-20200526211855-cb27e3aa2013.zip
# get https://goproxy.cn/google.golang.org/genproto/@v/v0.0.0-20200526211855-cb27e3aa2013.zip: 200 OK (0.149s)
# get https://goproxy.cn/sumdb/sum.golang.org/supported
# get https://goproxy.cn/sumdb/sum.golang.org/supported: 200 OK (0.097s)
# get https://goproxy.cn/sumdb/sum.golang.org/lookup/google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013
# get https://goproxy.cn/sumdb/sum.golang.org/lookup/google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013: 200 OK (0.036s)
# get https://goproxy.cn/sumdb/sum.golang.org/tile/8/0/x004/841
# get https://goproxy.cn/sumdb/sum.golang.org/tile/8/1/018
# get https://goproxy.cn/sumdb/sum.golang.org/tile/8/0/x004/841: 200 OK (0.030s)
# get https://goproxy.cn/sumdb/sum.golang.org/tile/8/1/018: 200 OK (0.033s)
# get https://goproxy.cn/github.com/hashicorp/golang-lru/v2/@v/v2.0.7.info
# get https://goproxy.cn/github.com/hashicorp/golang-lru/v2/@v/v2.0.7.info: 200 OK (0.090s)
# get https://goproxy.cn/github.com/xwb1989/sqlparser/@v/v0.0.0-20180606152119-120387863bf2.info
# get https://goproxy.cn/github.com/xwb1989/sqlparser/@v/v0.0.0-20180606152119-120387863bf2.info: 200 OK (0.039s)
/go/pkg/mod/google.golang.org/grpc@v1.71.0/status/status.go:35:2: ambiguous import: found package google.golang.org/genproto/googleapis/rpc/status in multiple modules:
        google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 (/go/pkg/mod/google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013/googleapis/rpc/status)
        google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a (/go/pkg/mod/google.golang.org/genproto/googleapis/rpc@v0.0.0-20250218202821-56aae31c358a/status)
/go/pkg/mod/github.com/grpc-ecosystem/grpc-gateway/v2@v2.26.1/runtime/handler.go:13:2: ambiguous import: found package google.golang.org/genproto/googleapis/api/httpbody in multiple modules:
        google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 (/go/pkg/mod/google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013/googleapis/api/httpbody)
        google.golang.org/genproto/googleapis/api v0.0.0-20250218202821-56aae31c358a (/go/pkg/mod/google.golang.org/genproto/googleapis/api@v0.0.0-20250218202821-56aae31c358a/httpbody)
/go/pkg/mod/go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc@v1.35.0/client.go:10:2: ambiguous import: found package google.golang.org/genproto/googleapis/rpc/errdetails in multiple modules:
        google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013 (/go/pkg/mod/google.golang.org/genproto@v0.0.0-20200526211855-cb27e3aa2013/googleapis/rpc/errdetails)
        google.golang.org/genproto/googleapis/rpc v0.0.0-20250218202821-56aae31c358a (/go/pkg/mod/google.golang.org/genproto/googleapis/rpc@v0.0.0-20250218202821-56aae31c358a/errdetails)


Stack:
[0]/script/tool/preprocess/find.go:86 tool/preprocess.runDryBuild
[1]/script/tool/preprocess/find.go:102 tool/preprocess.(*DepProcessor).findDeps
[2]/script/tool/preprocess/match.go:580 tool/preprocess.(*DepProcessor).matchRules
[3]/script/tool/preprocess/preprocess.go:305 tool/preprocess.Preprocess
[4]/script/tool/otel/main.go:130 main.main
[5]/usr/local/go/src/runtime/proc.go:283 runtime.mainr
```