### PR TITLE
fix: Fix the error in building sql demo

### DIFF
--- a/example/sqlinject/config.json
+++ b/example/sqlinject/config.json
@@ -3,5 +3,5 @@
   "Function": "Query",
   "ReceiverType": "*DB",
   "OnEnter": "sqlQueryOnEnter",
-  "Path": "sqlinjecthook"
+  "Path": "./rules"
 }]


### PR DESCRIPTION
Fix #579 

Compilation error caused by incorrect `Path` field.

The test result after repair is as follows:
```
#./sqlinjectdemo

2025/09/28 14:22:03 sqlQueryOnEnter potential SQL injection detected
```