### PR TITLE
feat: include transaction queue to display all items

### DIFF
--- a/pkg/rules/redigo/redigo_otel_conn.go
+++ b/pkg/rules/redigo/redigo_otel_conn.go
@@ -17,9 +17,11 @@ package redigo
 import (
 	"container/list"
 	"context"
+	"fmt"
 	"github.com/gomodule/redigo/redis"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 )
 
@@ -28,7 +30,7 @@ const max_queue_length = 2048
 var configuredQueueLength int
 
 var commandQueue = list.New()
-
+var transactionQueue = list.New() // transaction queue
 var redigoInstrumenter = BuildRedigoInstrumenter()
 
 type armsConn struct {
@@ -58,7 +60,37 @@ func (a *armsConn) Do(commandName string, args ...interface{}) (reply interface{
 	startTime := time.Now()
 	reply, err = a.Conn.Do(commandName, args...)
 	endTime := time.Now()
-	redigoInstrumenter.StartAndEnd(ctx, req, nil, err, startTime, endTime)
+	switch strings.ToLower(commandName) {
+	case "multi":
+		// Start of a transaction
+		push(req, transactionQueue)
+	case "exec":
+		// End of a transaction, we need to build the command string for all commands in the transaction
+		string_builder := strings.Builder{}
+		for transactionQueue.Len() > 0 {
+			r := pop(transactionQueue)
+			if r != nil && strings.ToLower(r.cmd) != "multi" {
+				string_builder.WriteString(r.cmd + " ")
+				for _, arg := range r.args {
+					string_builder.WriteString(fmt.Sprintf("%v ", arg))
+				}
+				string_builder.WriteString(";")
+			}
+		}
+		req.cmd = "EXEC"
+		req.args = []interface{}{string_builder.String()}
+		redigoInstrumenter.StartAndEnd(ctx, req, nil, err, startTime, endTime)
+	case "discard":
+		// Purge the transaction queue
+		transactionQueue.Init()
+	default:
+		// Inspect if we are in a transaction, otherwise just push to the command queue
+		if transactionQueue.Len() > 0 {
+			push(req, transactionQueue)
+			return
+		}
+		redigoInstrumenter.StartAndEnd(ctx, req, nil, err, startTime, endTime)
+	}
 	return
 }
 
@@ -75,7 +107,21 @@ func (a *armsConn) Send(commandName string, args ...interface{}) error {
 		ctx = context.Background()
 	}
 	req.ctx = ctx
-	push(req)
+	switch strings.ToLower(commandName) {
+	case "multi":
+		// Start of a transaction
+		push(req, transactionQueue)
+	case "discard":
+		// Purge the transaction queue
+		transactionQueue.Init()
+	default:
+		// Inspect if we are in a transaction, otherwise just push to the command queue
+		if transactionQueue.Len() > 0 {
+			push(req, transactionQueue)
+			return a.Conn.Send(commandName, args...)
+		}
+		push(req, commandQueue)
+	}
 	return a.Conn.Send(commandName, args...)
 }
 
@@ -85,7 +131,7 @@ func (a *armsConn) Flush() error {
 
 func (a *armsConn) Receive() (reply interface{}, err error) {
 	reply, err = a.Conn.Receive()
-	req := pop()
+	req := pop(commandQueue)
 	if req != nil {
 		now := time.Now()
 		redigoInstrumenter.StartAndEnd(req.ctx, req, nil, err, req.startTime, now)
@@ -93,16 +139,16 @@ func (a *armsConn) Receive() (reply interface{}, err error) {
 	return
 }
 
-func push(request *redigoRequest) {
-	if commandQueue != nil && commandQueue.Len() > getMaxQueueLength() {
+func push(request *redigoRequest, queue *list.List) {
+	if queue != nil && queue.Len() > getMaxQueueLength() {
 		return
 	}
-	commandQueue.PushBack(request)
+	queue.PushBack(request)
 }
 
-func pop() *redigoRequest {
-	front := commandQueue.Front()
-	commandQueue.Remove(front)
+func pop(queue *list.List) *redigoRequest {
+	front := queue.Front()
+	queue.Remove(front)
 	p, ok := front.Value.(*redigoRequest)
 	if ok {
 		return p


### PR DESCRIPTION
This pull request adds support for handling Redis transactions in the Redigo OpenTelemetry instrumentation. The main changes introduce a separate transaction queue to track commands between `MULTI` and `EXEC`, ensuring accurate tracing and reporting of transactional operations.

**Transaction handling improvements:**

* Introduced a new `transactionQueue` to separately track commands issued within a Redis transaction, allowing for correct grouping and reporting of transactional commands.
* Updated the `Do` and `Send` methods to push commands to the appropriate queue based on whether a transaction is active (`MULTI`, `EXEC`, or `DISCARD`), and to build a combined command string for all commands executed in a transaction. [[1]](diffhunk://#diff-cc7a333df569367960c0d993b5ff0317fe96cec60cd42036cbb44c20a824471eR63-R93) [[2]](diffhunk://#diff-cc7a333df569367960c0d993b5ff0317fe96cec60cd42036cbb44c20a824471eL78-R124)
* Added logic to purge the transaction queue on `DISCARD` and to process all queued transactional commands on `EXEC`. [[1]](diffhunk://#diff-cc7a333df569367960c0d993b5ff0317fe96cec60cd42036cbb44c20a824471eR63-R93) [[2]](diffhunk://#diff-cc7a333df569367960c0d993b5ff0317fe96cec60cd42036cbb44c20a824471eL78-R124)

**Queue management refactoring:**

* Refactored the `push` and `pop` helper functions to accept a queue parameter, making them reusable for both the command and transaction queues.
* Updated the `Receive` method to explicitly pop from the command queue, improving clarity and correctness.

**General improvements:**

* Added missing imports (`fmt`, `strings`) to support new string manipulation logic for transactional command reporting.